### PR TITLE
Improve Incomplete Tool Functionality

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,13 +26,14 @@ import topbar from "../vendor/topbar"
 import LazyImages from "./LazyImages";
 import SortableIssues from "./sortable_issues";
 import LongPressButton from "./long_press_button";
+import AutoResizeTextarea from "./auto_resize_textarea";
 import "./kill_button_toggle.js"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: { LazyImages, SortableIssues, LongPressButton }
+  hooks: { LazyImages, SortableIssues, LongPressButton, AutoResizeTextarea }
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/auto_resize_textarea.js
+++ b/assets/js/auto_resize_textarea.js
@@ -1,0 +1,24 @@
+/**
+ * AutoResizeTextarea Hook
+ *
+ * Automatically resizes a textarea to fit its content as the user types.
+ */
+const AutoResizeTextarea = {
+  mounted() {
+    this.resize()
+    this.el.addEventListener('input', () => this.resize())
+  },
+
+  updated() {
+    this.resize()
+  },
+
+  resize() {
+    // Reset height to auto to get the correct scrollHeight
+    this.el.style.height = 'auto'
+    // Set height to scrollHeight to fit all content
+    this.el.style.height = this.el.scrollHeight + 'px'
+  }
+}
+
+export default AutoResizeTextarea

--- a/lib/planning_poker/gitlab_api.ex
+++ b/lib/planning_poker/gitlab_api.ex
@@ -33,6 +33,7 @@ defmodule PlanningPoker.GitlabApi do
         id
         iid
         title
+        description
         descriptionHtml
         referencePath: reference(full: true)
         webUrl

--- a/lib/planning_poker/issue_editor.ex
+++ b/lib/planning_poker/issue_editor.ex
@@ -1,0 +1,141 @@
+defmodule PlanningPoker.IssueEditor do
+  @moduledoc """
+  Handles collaborative editing of issue descriptions by splitting them into
+  sections (separated by double newlines) with unique IDs.
+  """
+
+  @doc """
+  Parses markdown into sections, each with a unique ID.
+
+  Sections are split on double newlines (\\n\\n) to preserve natural markdown boundaries.
+
+  ## Examples
+
+      iex> parse_markdown("# Title\\n\\nParagraph 1\\n\\nParagraph 2")
+      [
+        %{id: "sec_...", content: "# Title", order: 0},
+        %{id: "sec_...", content: "Paragraph 1", order: 1},
+        %{id: "sec_...", content: "Paragraph 2", order: 2}
+      ]
+  """
+  def parse_markdown(nil), do: []
+  def parse_markdown(""), do: []
+
+  def parse_markdown(markdown) when is_binary(markdown) do
+    markdown
+    |> String.split("\n\n")
+    |> Enum.with_index()
+    |> Enum.map(fn {content, index} ->
+      %{
+        id: generate_section_id(),
+        content: String.trim(content),
+        order: index
+      }
+    end)
+    |> Enum.reject(fn section -> section.content == "" end)
+  end
+
+  @doc """
+  Converts sections back to markdown by joining with double newlines.
+
+  ## Examples
+
+      iex> sections_to_markdown([
+      ...>   %{id: "sec_1", content: "# Title", order: 0},
+      ...>   %{id: "sec_2", content: "Paragraph 1", order: 1}
+      ...> ])
+      "# Title\\n\\nParagraph 1"
+  """
+  def sections_to_markdown(sections) do
+    sections
+    |> Enum.sort_by(& &1.order)
+    |> Enum.map(& &1.content)
+    |> Enum.join("\n\n")
+  end
+
+  @doc """
+  Generates a unique section ID.
+
+  Format: "sec_" followed by 12 URL-safe random characters.
+  """
+  def generate_section_id do
+    random_string =
+      :crypto.strong_rand_bytes(9)
+      |> Base.url_encode64(padding: false)
+
+    "sec_#{random_string}"
+  end
+
+  @doc """
+  Finds a section by ID.
+  """
+  def find_section(sections, section_id) do
+    Enum.find(sections, fn section -> section.id == section_id end)
+  end
+
+  @doc """
+  Updates a section's content by ID.
+  """
+  def update_section(sections, section_id, new_content) do
+    Enum.map(sections, fn section ->
+      if section.id == section_id do
+        %{section | content: new_content}
+      else
+        section
+      end
+    end)
+  end
+
+  @doc """
+  Inserts a new empty section after the given section ID.
+  """
+  def insert_section_after(sections, after_section_id) do
+    after_index = Enum.find_index(sections, fn s -> s.id == after_section_id end)
+
+    case after_index do
+      nil ->
+        # Section not found, append to end
+        sections ++ [%{id: generate_section_id(), content: "", order: length(sections)}]
+
+      index ->
+        # Insert after the found section and reorder
+        {before, after_list} = Enum.split(sections, index + 1)
+        new_section = %{id: generate_section_id(), content: "", order: index + 1}
+
+        (before ++ [new_section] ++ after_list)
+        |> reorder_sections()
+    end
+  end
+
+  @doc """
+  Deletes a section by ID.
+  """
+  def delete_section(sections, section_id) do
+    sections
+    |> Enum.reject(fn s -> s.id == section_id end)
+    |> reorder_sections()
+  end
+
+  @doc """
+  Reorders sections sequentially based on their current position in the list.
+  """
+  def reorder_sections(sections) do
+    sections
+    |> Enum.with_index()
+    |> Enum.map(fn {section, index} ->
+      %{section | order: index}
+    end)
+  end
+
+  @doc """
+  Converts markdown content to HTML.
+  """
+  def markdown_to_html(markdown) when is_binary(markdown) do
+    case Earmark.as_html(markdown) do
+      {:ok, html, _} -> html
+      _ -> markdown
+    end
+  end
+
+  def markdown_to_html(_), do: ""
+end

--- a/lib/planning_poker/planning.ex
+++ b/lib/planning_poker/planning.ex
@@ -95,6 +95,27 @@ defmodule PlanningPoker.Planning do
     session_id |> to_pid |> :gen_statem.call(:complete_estimation)
   end
 
+  # Section editing operations
+  def lock_section(session_id, section_id, user_id) do
+    session_id |> to_pid |> :gen_statem.call({:lock_section, section_id, user_id})
+  end
+
+  def unlock_section(session_id, section_id, user_id) do
+    session_id |> to_pid |> :gen_statem.call({:unlock_section, section_id, user_id})
+  end
+
+  def update_section(session_id, section_id, new_content, user_id) do
+    session_id |> to_pid |> :gen_statem.call({:update_section, section_id, new_content, user_id})
+  end
+
+  def insert_section_after(session_id, section_id, user_id) do
+    session_id |> to_pid |> :gen_statem.call({:insert_section_after, section_id, user_id})
+  end
+
+  def delete_section(session_id, section_id, user_id) do
+    session_id |> to_pid |> :gen_statem.call({:delete_section, section_id, user_id})
+  end
+
   def to_pid(id) do
     [{pid, _value}] = Registry.lookup(PlanningPoker.PlanningSession.Registry, id)
     pid

--- a/lib/planning_poker_web/live/planning_session_live/editable_section_component.ex
+++ b/lib/planning_poker_web/live/planning_session_live/editable_section_component.ex
@@ -1,0 +1,187 @@
+defmodule PlanningPokerWeb.PlanningSessionLive.EditableSectionComponent do
+  use PlanningPokerWeb, :live_component
+
+  alias PlanningPoker.{Planning, IssueEditor}
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(:editing, false)
+     |> assign(:draft_content, assigns.section.content)}
+  end
+
+  @impl true
+  def handle_event("start_edit", _params, socket) do
+    section_id = socket.assigns.section.id
+    session_id = socket.assigns.session_id
+    user_id = socket.assigns.current_user_id
+
+    case Planning.lock_section(session_id, section_id, user_id) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> assign(:editing, true)
+         |> assign(:draft_content, socket.assigns.section.content)}
+
+      {:error, :locked_by_other} ->
+        {:noreply, put_flash(socket, :error, "This section is being edited by someone else")}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("cancel_edit", _params, socket) do
+    section_id = socket.assigns.section.id
+    session_id = socket.assigns.session_id
+    user_id = socket.assigns.current_user_id
+
+    Planning.unlock_section(session_id, section_id, user_id)
+
+    {:noreply,
+     socket
+     |> assign(:editing, false)
+     |> assign(:draft_content, socket.assigns.section.content)}
+  end
+
+  @impl true
+  def handle_event("save_edit", %{"content" => content}, socket) do
+    section_id = socket.assigns.section.id
+    session_id = socket.assigns.session_id
+    user_id = socket.assigns.current_user_id
+
+    case Planning.update_section(session_id, section_id, content, user_id) do
+      :ok ->
+        Planning.unlock_section(session_id, section_id, user_id)
+        {:noreply, assign(socket, :editing, false)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to save section")}
+    end
+  end
+
+  @impl true
+  def handle_event("update_draft", %{"value" => value}, socket) do
+    {:noreply, assign(socket, :draft_content, value)}
+  end
+
+  @impl true
+  def handle_event("insert_after", _params, socket) do
+    section_id = socket.assigns.section.id
+    session_id = socket.assigns.session_id
+    user_id = socket.assigns.current_user_id
+
+    case Planning.insert_section_after(session_id, section_id, user_id) do
+      {:ok, _new_section_id} ->
+        {:noreply, socket}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to insert section")}
+    end
+  end
+
+  @impl true
+  def handle_event("delete_section", _params, socket) do
+    section_id = socket.assigns.section.id
+    session_id = socket.assigns.session_id
+    user_id = socket.assigns.current_user_id
+
+    case Planning.delete_section(session_id, section_id, user_id) do
+      :ok ->
+        {:noreply, socket}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to delete section")}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    # Determine lock status
+    lock_info = Map.get(assigns.locks, assigns.section.id)
+    locked_by_me = lock_info && lock_info.user_id == assigns.current_user_id
+    locked_by_other = lock_info && lock_info.user_id != assigns.current_user_id
+
+    assigns =
+      assigns
+      |> assign(:lock_info, lock_info)
+      |> assign(:locked_by_me, locked_by_me)
+      |> assign(:locked_by_other, locked_by_other)
+
+    ~H"""
+    <div class="editable-section group relative mb-4 p-4 border border-gray-200 rounded-lg hover:border-blue-300 transition-colors">
+      <%= if @locked_by_other do %>
+        <div class="absolute top-2 right-2 text-xs text-yellow-600 bg-yellow-50 px-2 py-1 rounded">
+          <.icon name="hero-lock-closed" class="w-3 h-3 inline" /> Editing...
+        </div>
+      <% end %>
+
+      <%= if @editing do %>
+        <div class="space-y-2">
+          <textarea
+            id={"section-textarea-#{@section.id}"}
+            phx-hook="AutoResizeTextarea"
+            phx-target={@myself}
+            phx-change="update_draft"
+            name="content"
+            class="w-full min-h-[100px] p-2 border border-blue-400 rounded font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            phx-debounce="300"
+          ><%= @draft_content %></textarea>
+
+          <div class="flex gap-2">
+            <button
+              phx-click="save_edit"
+              phx-target={@myself}
+              class="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm"
+            >
+              Save
+            </button>
+            <button
+              phx-click="cancel_edit"
+              phx-target={@myself}
+              class="px-3 py-1 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 text-sm"
+            >
+              Cancel
+            </button>
+            <%= if @locked_by_me do %>
+              <button
+                phx-click="delete_section"
+                phx-target={@myself}
+                class="ml-auto px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
+                data-confirm="Delete this section?"
+              >
+                <.icon name="hero-trash" class="w-4 h-4" />
+              </button>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <div
+          phx-click={unless(@locked_by_other, do: "start_edit")}
+          phx-target={@myself}
+          class={[
+            "prose prose-sm max-w-none cursor-pointer",
+            @locked_by_other && "opacity-60 cursor-not-allowed"
+          ]}
+        >
+          <%= raw(IssueEditor.markdown_to_html(@section.content)) %>
+        </div>
+
+        <%= if !@locked_by_other do %>
+          <button
+            phx-click="insert_after"
+            phx-target={@myself}
+            class="absolute -bottom-3 left-1/2 transform -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity bg-blue-500 text-white rounded-full w-6 h-6 flex items-center justify-center hover:bg-blue-600 shadow-md"
+            title="Insert section below"
+          >
+            <.icon name="hero-plus" class="w-4 h-4" />
+          </button>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/planning_poker_web/live/planning_session_live/show.html.heex
+++ b/lib/planning_poker_web/live/planning_session_live/show.html.heex
@@ -7,12 +7,15 @@
           id="lobby"
           data={data}
         />
-      <% %{state: :voting, current_issue: issue} -> %>
+      <% %{state: :voting, current_issue: issue} = data -> %>
         <.live_component
           module={PlanningPokerWeb.PlanningSessionLive.VotingComponent}
           id="voting"
           issue={issue}
-          mode={@planning_session.mode}
+          mode={data.mode}
+          issue_edit={data[:issue_edit]}
+          session_id={data.id}
+          current_user_id={@current_participant.id}
         />
       <% %{state: :magic_estimation} = data -> %>
         <.live_component

--- a/lib/planning_poker_web/live/planning_session_live/voting_component.ex
+++ b/lib/planning_poker_web/live/planning_session_live/voting_component.ex
@@ -1,18 +1,68 @@
 defmodule PlanningPokerWeb.PlanningSessionLive.VotingComponent do
   use PlanningPokerWeb, :live_component
 
+  alias PlanningPokerWeb.PlanningSessionLive.EditableSectionComponent
+  alias PlanningPoker.Planning
+
+  def handle_event("insert_at_end", _params, socket) do
+    session_id = socket.assigns.session_id
+    user_id = socket.assigns.current_user_id
+
+    # Get the last section ID
+    last_section =
+      socket.assigns.issue_edit.sections
+      |> Enum.max_by(& &1.order, fn -> nil end)
+
+    case last_section do
+      nil ->
+        {:noreply, socket}
+
+      section ->
+        Planning.insert_section_after(session_id, section.id, user_id)
+        {:noreply, socket}
+    end
+  end
+
   def render(assigns) do
     ~H"""
     <main>
       <.layout_box title="Voting">
-        <h1 class="text-4xl font-semibold">
+        <h1 class="text-4xl font-semibold mb-6">
           <a class="underline decoration-primary hover:decoration-primary/50 decoration-4" href={@issue["webUrl"]} target="_blank">
             <%= @issue["title"] %>
           </a>
         </h1>
-        <div id="issue-description" class="prose prose-lg" phx-hook="LazyImages" data-base-url={@issue[:base_url]}>
-          <%= raw(@issue["descriptionHtml"]) %>
+
+        <div class="space-y-4">
+          <%= if @issue_edit && length(@issue_edit.sections) > 0 do %>
+            <%= for section <- Enum.sort_by(@issue_edit.sections, & &1.order) do %>
+              <.live_component
+                module={EditableSectionComponent}
+                id={"section-#{section.id}"}
+                section={section}
+                locks={@issue_edit.locks}
+                session_id={@session_id}
+                current_user_id={@current_user_id}
+              />
+            <% end %>
+
+            <div class="flex justify-center mt-6">
+              <button
+                phx-click="insert_at_end"
+                phx-target={@myself}
+                class="btn btn-outline btn-sm gap-2"
+              >
+                <.icon name="hero-plus-circle" class="w-5 h-5" />
+                Add Section
+              </button>
+            </div>
+          <% else %>
+            <div id="issue-description" class="prose prose-lg" phx-hook="LazyImages" data-base-url={@issue[:base_url]}>
+              <%= raw(@issue["descriptionHtml"]) %>
+            </div>
+          <% end %>
         </div>
+
         <:controls>
           <button class="btn" phx-click={if @mode == :magic_estimation, do: "back_to_lobby", else: "finish_voting"}>
             <%= if @mode == :magic_estimation, do: "Back", else: "Finish Voting" %>

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,8 @@ defmodule PlanningPoker.MixProject do
       {:tesla, "~> 1.14"},
       {:elixir_uuid, "~> 1.2"},
       {:ueberauth, "~> 0.7.0"},
-      {:ueberauth_gitlab_strategy, "~> 0.4.0"}
+      {:ueberauth_gitlab_strategy, "~> 0.4.0"},
+      {:earmark, "~> 1.4"}
     ]
   end
 


### PR DESCRIPTION
This commit implements a collaborative editing system that allows multiple participants to edit issue descriptions during planning sessions. The feature splits markdown descriptions into sections (separated by double newlines) and enables concurrent editing with section-level locking.

Key Features:
- Section-based editing: Markdown is split on double newlines (\n\n) into editable sections with unique IDs
- Concurrent editing: Multiple users can edit different sections simultaneously
- Section locking: Prevents conflicts by locking sections during editing
- Real-time sync: All participants see changes instantly via PubSub
- Plain text editing: Simple textarea interface for markdown content
- Insert/delete sections: Add new sections between existing ones or remove them
- Auto-resize textarea: Automatically adjusts height as content grows

Architecture Changes:
- GitlabApi: Now fetches both 'description' (markdown) and 'descriptionHtml'
- IssueEditor: New module for parsing markdown into sections, managing IDs, and converting markdown to HTML using Earmark
- PlanningSession: Enhanced gen_statem with section editing state and events:
  - lock_section: Acquire exclusive edit lock
  - unlock_section: Release edit lock
  - update_section: Save changes to section content
  - insert_section_after: Create new section below existing one
  - delete_section: Remove a section
- Planning: Added helper functions for section operations
- EditableSectionComponent: LiveView component for rendering and editing sections with lock indicators and controls
- VotingComponent: Updated to render editable sections instead of static HTML
- AutoResizeTextarea: JavaScript hook for dynamic textarea sizing

State Structure:
issue_edit: %{
  sections: [%{id: "sec_...", content: "...", order: 0}, ...], locks: %{"sec_id" => %{user_id: "...", locked_at: ~U[...]}} }

Benefits:
- Improves planning sessions by allowing participants to collaboratively refine issue descriptions in real-time
- Prevents editing conflicts through section-level locking
- Maintains markdown format for GitLab compatibility
- Provides immediate visual feedback of who is editing what

🤖 Generated with [Claude Code](https://claude.com/claude-code)