### PR TITLE
Add GitLab proxy endpoint for cross-domain assets

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,13 +28,14 @@ import SortableIssues from "./sortable_issues";
 import LongPressButton from "./long_press_button";
 import SectionEditor from "./section_editor";
 import PersonalIssueNotes from "./personal_issue_notes";
+import ProxyGitLabAssets from "./proxy_gitlab_assets";
 import "./kill_button_toggle.js"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: { LazyImages, SortableIssues, LongPressButton, SectionEditor, PersonalIssueNotes }
+  hooks: { LazyImages, SortableIssues, LongPressButton, SectionEditor, PersonalIssueNotes, ProxyGitLabAssets }
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/proxy_gitlab_assets.js
+++ b/assets/js/proxy_gitlab_assets.js
@@ -1,0 +1,45 @@
+/**
+ * ProxyGitLabAssets Hook
+ *
+ * Rewrites GitLab asset URLs (images, videos) to use the local proxy endpoint.
+ * This works around cross-domain cookie issues in Firefox where cookies aren't
+ * sent for cross-origin image requests.
+ *
+ * Transforms URLs like:
+ *   https://gitlab.sys.mixxt.net/uploads/foo/bar.png
+ * To:
+ *   /proxy/uploads/foo/bar.png
+ */
+
+export default {
+  mounted() {
+    this.rewriteGitLabUrls();
+  },
+
+  updated() {
+    this.rewriteGitLabUrls();
+  },
+
+  rewriteGitLabUrls() {
+    // Get GitLab site URL from data attribute
+    const gitlabSite = this.el.dataset.gitlabSite;
+    if (!gitlabSite) {
+      console.warn("ProxyGitLabAssets hook: data-gitlab-site attribute not found");
+      return;
+    }
+
+    // Find all images and videos with GitLab URLs
+    const assets = this.el.querySelectorAll(`img[src^="${gitlabSite}/uploads/"], video[src^="${gitlabSite}/uploads/"]`);
+
+    assets.forEach(asset => {
+      const originalSrc = asset.src;
+
+      // Check if already proxied to avoid double-rewriting
+      if (!originalSrc.startsWith("/proxy/")) {
+        // Replace GitLab domain with local proxy path
+        const proxiedSrc = originalSrc.replace(`${gitlabSite}/uploads/`, "/proxy/uploads/");
+        asset.src = proxiedSrc;
+      }
+    });
+  }
+};

--- a/lib/planning_poker_web/components/planning_components.ex
+++ b/lib/planning_poker_web/components/planning_components.ex
@@ -1,0 +1,43 @@
+defmodule PlanningPokerWeb.PlanningComponents do
+  @moduledoc """
+  Provides planning-specific UI components.
+  """
+  use Phoenix.Component
+
+  @doc """
+  Renders a profile image, automatically proxying GitLab URLs to work around
+  cross-domain cookie issues.
+
+  ## Examples
+
+      <.profile_image src={user.avatar} alt={user.name} class="w-8 h-8" />
+      <.profile_image src={user.avatar} aria-hidden="true" />
+  """
+  attr :src, :string, required: true, doc: "the image source URL"
+  attr :alt, :string, default: "", doc: "the image alt text"
+  attr :class, :string, default: "", doc: "additional CSS classes"
+  attr :rest, :global, doc: "arbitrary HTML attributes (aria-hidden, etc.)"
+
+  def profile_image(assigns) do
+    assigns = assign(assigns, :proxied_src, proxy_gitlab_url(assigns.src))
+
+    ~H"""
+    <img src={@proxied_src} alt={@alt} class={@class} {@rest} />
+    """
+  end
+
+  # Rewrites GitLab URLs to use the proxy endpoint
+  defp proxy_gitlab_url(url) when is_binary(url) do
+    gitlab_site = System.get_env("GITLAB_SITE", "https://gitlab.com")
+
+    if String.starts_with?(url, "#{gitlab_site}/uploads/") do
+      # Replace GitLab domain with local proxy path
+      String.replace_prefix(url, "#{gitlab_site}/uploads/", "/proxy/uploads/")
+    else
+      # Non-GitLab URLs pass through unchanged (e.g., ui-avatars.com for mock users)
+      url
+    end
+  end
+
+  defp proxy_gitlab_url(nil), do: ""
+end

--- a/lib/planning_poker_web/controllers/uploads_proxy_controller.ex
+++ b/lib/planning_poker_web/controllers/uploads_proxy_controller.ex
@@ -1,0 +1,81 @@
+defmodule PlanningPokerWeb.UploadsProxyController do
+  @moduledoc """
+  Proxies requests to GitLab uploads to work around cross-domain cookie issues.
+
+  Firefox doesn't send cookies for cross-domain image requests, which causes
+  authentication failures when loading GitLab assets. This controller proxies
+  the requests using the user's session token.
+  """
+
+  use PlanningPokerWeb, :controller
+  require Logger
+
+  @doc """
+  Fetches an asset from GitLab uploads and streams it to the client.
+
+  The path parameter contains the full path after /proxy/uploads/, which is
+  prepended with the GitLab site URL to construct the full asset URL.
+
+  Example:
+    Request: /proxy/uploads/-/system/user/avatar/19/avatar.png
+    Proxied to: https://gitlab.sys.mixxt.net/uploads/-/system/user/avatar/19/avatar.png
+  """
+  def fetch(conn, %{"path" => path}) do
+    case get_session(conn, :token) do
+      nil ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Authentication required"})
+
+      token ->
+        # Construct full GitLab URL
+        gitlab_site = System.get_env("GITLAB_SITE", "https://gitlab.com")
+        url = "#{gitlab_site}/uploads/#{Enum.join(path, "/")}"
+
+        fetch_and_stream(conn, url, token)
+    end
+  end
+
+  defp fetch_and_stream(conn, url, token) do
+    # Create Tesla client with authorization
+    client =
+      Tesla.client([
+        {Tesla.Middleware.Headers, [{"Authorization", "Bearer #{token}"}]}
+      ])
+
+    case Tesla.get(client, url) do
+      {:ok, %Tesla.Env{status: 200, headers: headers, body: body}} ->
+        content_type = get_header_value(headers, "content-type", "application/octet-stream")
+
+        conn
+        |> put_resp_content_type(content_type)
+        |> put_resp_header("cache-control", "public, max-age=3600")
+        |> send_resp(200, body)
+
+      {:ok, %Tesla.Env{status: 404}} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "Asset not found"})
+
+      {:ok, %Tesla.Env{status: status}} ->
+        Logger.warning("Proxy fetch returned status #{status} for URL: #{url}")
+
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{error: "Failed to fetch asset (status: #{status})"})
+
+      {:error, reason} ->
+        Logger.error("Proxy fetch failed: #{inspect(reason)}")
+
+        conn
+        |> put_status(:bad_gateway)
+        |> json(%{error: "Failed to fetch asset"})
+    end
+  end
+
+  defp get_header_value(headers, key, default) do
+    Enum.find_value(headers, default, fn {k, v} ->
+      if String.downcase(k) == String.downcase(key), do: v
+    end)
+  end
+end

--- a/lib/planning_poker_web/live/planning_session_live/collaborative_issue_editor_component.ex
+++ b/lib/planning_poker_web/live/planning_session_live/collaborative_issue_editor_component.ex
@@ -1,13 +1,17 @@
 defmodule PlanningPokerWeb.PlanningSessionLive.CollaborativeIssueEditorComponent do
   use PlanningPokerWeb, :live_component
 
+  import PlanningPokerWeb.PlanningComponents
+
   alias PlanningPoker.Planning
   require Logger
 
   @impl true
   def render(assigns) do
+    assigns = assign(assigns, :gitlab_site, System.get_env("GITLAB_SITE", "https://gitlab.com"))
+
     ~H"""
-    <div class="collaborative-editor prose prose-lg max-w-none">
+    <div class="collaborative-editor prose prose-lg max-w-none" phx-hook="ProxyGitLabAssets" data-gitlab-site={@gitlab_site} id="collaborative-editor">
       <div :if={@issue["sections"]} class="sections-container">
         <%= for {section, index} <- Enum.with_index(@issue["sections"]) do %>
           <% is_edited =
@@ -90,7 +94,7 @@ defmodule PlanningPokerWeb.PlanningSessionLive.CollaborativeIssueEditorComponent
                           <div class="status status-warning animate-ping w-6 h-6"></div>
                           <div class="avatar">
                             <div class="w-6 h-6 rounded-full">
-                              <img src={locked_by_user.avatar} alt={locked_by_user.name} />
+                              <.profile_image src={locked_by_user.avatar} alt={locked_by_user.name} />
                             </div>
                           </div>
                         </div>

--- a/lib/planning_poker_web/live/planning_session_live/participants_list_component.ex
+++ b/lib/planning_poker_web/live/planning_session_live/participants_list_component.ex
@@ -1,6 +1,8 @@
 defmodule PlanningPokerWeb.PlanningSessionLive.ParticipantsListComponent do
   use PlanningPokerWeb, :live_component
 
+  import PlanningPokerWeb.PlanningComponents
+
   def render(assigns) do
     ~H"""
     <aside>
@@ -9,7 +11,7 @@ defmodule PlanningPokerWeb.PlanningSessionLive.ParticipantsListComponent do
           <%= for participant <- @participants do %>
             <li class="flex items-center gap-2 relative">
               <div class="avatar h-10 w-10">
-                <img class={"mask mask-squircle #{if participant[:vote], do: "blur-sm grayscale", else: ""}"} src={participant.avatar} aria-hidden="true" />
+                <.profile_image class={"mask mask-squircle #{if participant[:vote], do: "blur-sm grayscale", else: ""}"} src={participant.avatar} aria-hidden="true" />
                 <%= if participant[:vote] do %>
                   <.icon name="hero-check-badge-solid" class="text-success absolute h-10 w-10" />
                 <% end %>

--- a/lib/planning_poker_web/router.ex
+++ b/lib/planning_poker_web/router.ex
@@ -32,6 +32,7 @@ defmodule PlanningPokerWeb.Router do
 
     live "/", PlanningSessionLive.Show
     get "/participate", ParticipationController, :new
+    get "/proxy/uploads/*path", UploadsProxyController, :fetch
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## Summary

- Fixes cross-domain cookie issues in Firefox where GitLab assets fail to load
- Adds proxy endpoint for GitLab uploads (profile images, issue images/videos)
- Creates reusable `.profile_image` component for automatic URL rewriting
- Implements JavaScript hook for dynamic content in issue descriptions

## Problem

Firefox doesn't send cookies for cross-origin image requests, causing GitLab-hosted assets to fail authentication. This affects:
- User profile avatars (e.g., `https://gitlab.sys.mixxt.net/uploads/-/system/user/avatar/19/avatar.png`)
- Images and videos embedded in issue descriptions

## Solution

**Server-side proxy:**
- New `UploadsProxyController` at `/proxy/uploads/*path`
- Fetches assets from GitLab using user's session token
- Streams response with proper content-type and cache headers
- Only proxies to configured `GITLAB_SITE` (security)

**Client-side components:**
- `PlanningComponents.profile_image/1` - Automatically rewrites avatar URLs
- `ProxyGitLabAssets` hook - Rewrites image/video URLs in issue content
- URLs transformed: `https://gitlab.sys.mixxt.net/uploads/foo.png` → `/proxy/uploads/foo.png`

## Files Changed

**New files:**
- `lib/planning_poker_web/controllers/uploads_proxy_controller.ex` - Proxy controller
- `lib/planning_poker_web/components/planning_components.ex` - Planning domain components
- `assets/js/proxy_gitlab_assets.js` - JavaScript hook for issue content

**Modified files:**
- `lib/planning_poker_web/router.ex` - Add proxy route
- `lib/planning_poker_web/live/planning_session_live/participants_list_component.ex` - Use `.profile_image`
- `lib/planning_poker_web/live/planning_session_live/collaborative_issue_editor_component.ex` - Use `.profile_image` and hook
- `assets/js/app.js` - Register hook

## Security

✓ Session authentication required  
✓ Only proxies to configured `GITLAB_SITE`  
✓ Path-based routing (not URL parameter) prevents open proxy abuse  
✓ Proper error handling (401, 404, 502)

## Test Plan

- [ ] Login with GitLab OAuth
- [ ] Verify profile avatars display in participants list
- [ ] Verify "locked by" avatars display in collaborative editor
- [ ] Add issue with embedded GitLab images/videos
- [ ] Verify images/videos load correctly in issue descriptions
- [ ] Test in Firefox (primary fix target)
- [ ] Test with mock provider (should pass through non-GitLab URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)